### PR TITLE
Updating the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,26 @@ Once the `eslint-config-smashing-boxes` package is installed, you can use it by 
 
 ### React
 
-For usage in a React project, change the `"extends"` value to `"extends": "smashing-boxes/react"`
+For usage in a React project you will need to install the `eslint-plugin-react`:
+
+```
+npm install --save-dev eslint-plugin-react
+```
+
+Change the `"extends"` value to `"extends": "smashing-boxes/react"` or `"extends": "eslint-config-smashing-boxes/react"`
+
+```js
+{
+  "extends": "smashing-boxes/react", // Or "eslint-config-smashing-boxes/react"
+  "rules": {
+
+    /**
+     * Additional, per-project rules can go here.
+     * These rules will override the rules in
+     * "eslint-config-smashing-boxes"
+     */
+
+```
 
 ## License
 


### PR DESCRIPTION
### WHY?
- The `README.md` didn't specify that you needed to install the React ESLint plugin if you were going to use the React config.

### WHAT?
- Updated the `README.md` to tell what plugin to install.