### PR TITLE
Updating indent rule for switch statements

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -298,7 +298,6 @@ module.exports = {
     "sort-imports": "off",                                            // http://eslint.org/docs/rules/sort-imports
     "symbol-description": "off",                                      // http://eslint.org/docs/rules/symbol-description
     "template-curly-spacing": "error",                                // http://eslint.org/docs/rules/template-curly-spacing
-    "yield-star-spacing": "error",                                    // http://eslint.org/docs/rules/yield-star-spacing
-
+    "yield-star-spacing": "error"                                     // http://eslint.org/docs/rules/yield-star-spacing
   }
 };

--- a/defaults.js
+++ b/defaults.js
@@ -189,7 +189,7 @@ module.exports = {
     "id-blacklist": "off",                                            // http://eslint.org/docs/rules/id-blacklist
     "id-length": "off",                                               // http://eslint.org/docs/rules/id-length
     "id-match": "off",                                                // http://eslint.org/docs/rules/id-match
-    "indent": ["error", 2],                                           // http://eslint.org/docs/rules/indent
+    "indent": ["error", 2, { "SwitchCase": 1 }],                      // http://eslint.org/docs/rules/indent
     "jsx-quotes": "error",                                            // http://eslint.org/docs/rules/jsx-quotes
     "key-spacing": "error",                                           // http://eslint.org/docs/rules/key-spacing
     "keyword-spacing": "error",                                       // http://eslint.org/docs/rules/keyword-spacing


### PR DESCRIPTION
# WHY?

Our current `es-lint` rules make it so that `case` has the same indentation as `switch`. This will apply one indentation to the `case` lines. Even [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch) has indentation for `case` within their `switch` statement documentation.

# WHAT?
- Updated the config to require one indentation for `case` inside `switch`. Refer to the configuration found [here](http://eslint.org/docs/rules/indent#switchcase)