### PR TITLE
Remove the need to put new in front of creating ImmutableJS objects

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -206,7 +206,8 @@ module.exports = {
     "max-statements": "off",                                          // http://eslint.org/docs/rules/max-statements
     "multiline-ternary": "off",                                       // http://eslint.org/docs/rules/multiline-ternary
     "new-cap": ["error", {                                            // http://eslint.org/docs/rules/new-cap
-      "capIsNewExceptionPattern" : "^Immutable\\.."
+      "capIsNewExceptionPattern" : "^Immutable\\..",
+      "newIsCap": true
     }],
     "new-parens": "error",                                            // http://eslint.org/docs/rules/new-parens
     "newline-after-var": "off",                                       // http://eslint.org/docs/rules/newline-after-var

--- a/defaults.js
+++ b/defaults.js
@@ -206,8 +206,7 @@ module.exports = {
     "max-statements": "off",                                          // http://eslint.org/docs/rules/max-statements
     "multiline-ternary": "off",                                       // http://eslint.org/docs/rules/multiline-ternary
     "new-cap": ["error", {                                            // http://eslint.org/docs/rules/new-cap
-      "capIsNewExceptions": ["Record"],
-      "newIsCap": true
+      "capIsNewExceptionPattern" : "^Immutable\\.."
     }],
     "new-parens": "error",                                            // http://eslint.org/docs/rules/new-parens
     "newline-after-var": "off",                                       // http://eslint.org/docs/rules/newline-after-var


### PR DESCRIPTION
# WHY?

Because the ImmutableJS object creation functions aren't constructors and nothing is gained by the linter requiring them to be preceded with `new` as shown below:

`const map = new Immutable.Map();`

instead of just doing

`const map = Immutable.Map();`


# WHAT?
- Used the `capIsNewExceptionPattern` so that the rule is not enforced if it begins with `Immutable.` (e.g. `Immutable.List()`, `Immutable.Map()`, etc.). See documentation [here](https://eslint.org/docs/rules/new-cap#capisnewexceptionpattern)
- Removed the `newIsCap: true` rule because it appears that it's a default. See [here](https://eslint.org/docs/rules/new-cap#options)

I chose to use the pattern for the exception handling rather than just listing out the exceptions (how it was for `Record`) which will require users to do `import Immutable from 'immutable';` rather than `import { Map } from 'immutable;`. I feel that gives more flexibility as Immutable's API/functionality could change in the future.

### Current

<img width="1107" alt="new cap - current" src="https://user-images.githubusercontent.com/10897808/30526512-85057488-9be9-11e7-8fa8-cdcd0733fd23.png">


### Update

<img width="1055" alt="new cap - update" src="https://user-images.githubusercontent.com/10897808/30526517-8874ea36-9be9-11e7-98bf-9c0889ac491b.png">
